### PR TITLE
Manpage improvements.

### DIFF
--- a/doc/btcli.1
+++ b/doc/btcli.1
@@ -1,262 +1,282 @@
-.TH BTCLI "1" "2010\-07\-31" "BitTorrent Protocol Daemon 0.16" "User Commands"
-.\" disable hyphenation
-.nh
-.\" adjust text to left margin only
-.ad l
-.\" -----------------------------------------------------------------
-.\" MAIN CONTENT
-.\" -----------------------------------------------------------------
-.SH "NAME"
-btcli \- command line interface to btpd
-.SH "SYNOPSIS"
-.B btcli
-\fIOPERATION\fR [\fIOPERATION_OPTIONS\fR]
-.SH "DESCRIPTION"
-.PP
-\fBbtcli\fR is a utility that interacts with a running btpd daemon.
+.Dd May 10, 2015
+.Dt BTCLI 1
+.Os
+.Sh NAME
+.Nm btcli
+.Nd command line interface to btpd
+.Sh SYNOPSIS
+.Nm btcli
+.Ar operation
+.Op Ar options
+.Sh DESCRIPTION
+.Nm
+is a utility that interacts with a running
+.Xr btpd 1
+daemon.
 It has several different modes of operation.
-.SH "OPERATIONS"
-.PP
+.Sh OPERATIONS
 One of the following operations must be specified when running btcli:
-.TP
-\fBadd\fR \- Add torrents to btpd.
-.TP
-\fBdel\fR \- Remove torrents from btpd.
-.TP
-\fBkill\fR \- Shut down btpd.
-.TP
-\fBlist\fR \- List torrents.
-.TP
-\fBrate\fR \- Set the global up and download rates in KB/s.
-.TP
-\fBstart\fR \- Activate torrents.
-.TP
-\fBstat\fR \- Display stats for active torrents.
-.TP
-\fBstop\fR \- Deactivate torrents.
-.TP
-\fB\-\-help\fR \fIOPERATION\fR Show help for the specified operation.
-.SH "ADD OPTIONS"
-.TP
-\fB\-d\fR dir
-Specifies the directory in which the files in the torrent will be downloaded;
-It does not specify \fBbtpd\fR's "work" directory.
-That is gathered from the environment variable \fI$HOME\fR.
-.TP
-\fB\-N, \-\-nostart\fR
-Do not start the torrent immediately after adding it.
-.TP
-\fB\-T, \-\-topdir\fR
-Append the torrent top directory (if any) to the content path.
-.TP
-\fB\-n\fR name
-Specifies the name to be displayed for this torrent.
-.TP
-\fB\-l\fR label
-Set the label to associate with torrent.
-.SH "LIST OPTIONS"
-.TP
-\fB\-a\fR
-List active torrents.
-.TP
-\fB\-i\fR
-List inactive torrents.
-.TP
-\fB\-f\fR format
-Specifies a custom format to use while displaying torrents.  The following is a
-list of the characters that can be used:
-.RS 8
-.PP
-\fB%n\fR \- torrent name
-.br
-\fB%#\fR \- torrent number
-.br
-\fB%h\fR \- torrent hash
-.br
-\fB%l\fR \- torrent label
-.br
-\fB%d\fR \- download directory
-.br
-\fB%t\fR \- state
-.br
-\fB%P\fR \- peer count
-.PP
-\fB%^\fR \- upload rate
-.br
-\fB%v\fR \- download rate
-.PP
-\fB%D\fR \- downloaded bytes
-.br
-\fB%U\fR \- uploaded bytes
-.br
-\fB%g\fR \- bytes got
-.br
-\fB%u\fR \- bytes uploaded
-.br
-\fB%s\fR \- total size, (formatted: prints K, M, G)
-.br
-\fB%S\fR \- total size, in bytes
-.PP
-\fB%A\fR \- available pieces
-.br
-\fB%T\fR \- total pieces
-.br
-\fB%H\fR \- have pieces
-.PP
-\fB%p\fR \- percent have (formatted)
-.br
-\fB%r\fR \- ratio
-.PP
-\fB%%\fR \- a percent symbol: '%'
-.RE
-.SH "STAT OPTIONS"
-.TP
-\fB\-i\fR
-Display individual lines for each torrent.
-.TP
-\fB\-n\fR
-Display the name of each torrent.  Implies '\-i'.
-.SH "START OPTIONS"
-.TP
-\fB\-a\fR
-Activate all non\-active torrents.
-.SH "STOP OPTIONS"
-.TP
-\fB\-a\fR
-Deactivate all torrents.
-.SH "USAGE"
-.PP
-btpd must be started before btcli can be used.  See \fBbtpd\fR(1) for help with starting btpd.
-.PP
-To start sharing a torrent with btpd, the torrent needs to be added to btpd. This is done with \fBbtcli add\fR. Unless otherwise specified, btpd automatically starts to share the torrent and download any missing data. If the content directory you specify when adding a torrent does not exist, btpd will create it.
-.PP
-You can see which torrents have been added to btpd with \fBbtcli list\fR.  The list mode also displays a number for each added torrent. This number can be used to specify the target torrent for the btcli modes, so you don't have to keep the torrent file after adding it.
-.PP
-The up\- and download progress can be followed by using the \fBbtcli stat\fR mode. Both the list and stat modes use the following indicators to display the state of a torrent:
-.RS 4
-.TP 4
-\fB+\fR
-The torrent is starting. This may take time if btpd needs to test the content of this torrent or one started before it.
-.TP 4
-\fB\-\fR
-The torrent is being stopped.
-.TP 4
-\fBI\fR
-The torrent is inactive.
-.TP 4
-\fBS\fR
-btpd is seeding the torrent.
-.TP 4
-\fBL\fR
-btpd is leeching the torrent.
-.RE
-.PP
-You can stop an active torrent with \fBbtcli stop\fR.  You can start an inactive torrent by using \fBbtcli start\fR.
-.PP
-.B Note:
-Torrents can be specified either with its number or its file.
-.PP
-The \fBbtcli del\fR mode should only be used when you're totally finished with sharing a torrent. The mode will remove the torrent and its associated data from btpd. It is a bad idea to remove a not fully downloaded torrent and then add it again, since btpd has lost information on the not fully downloaded pieces and will need to download the data again.
-.PP
-To shut down btpd use \fBbtcli kill\fR.
-
-.SH "EXAMPLES"
-Display a list btpd's torrents and their number, size, status, etc.
-.RS 4
-.B $ btcli list
-.RE
-.PP
-Same as above, but only for torrent 12 and my.little.torrent.
-.br
-.RS 4
-.B $ btcli list 12 my.little.torrent
-.RE
-.PP
-Same as above but only for active torrents.
-.br
-.RS 4
-.B $ btcli list \-a
-.RE
-.PP
-Add foo.torrent, with content dir foo.torrent.d, and start it.
-.br
-.RS 4
-.B $ btcli add \-d foo.torrent.d foo.torrent
-.RE
-.PP
-Same as above without starting it.
-.br
-.RS 4
-.B $ btcli add \-\-no\-start \-d foo.torrent.d foo.torrent
-.RE
-.PP
-Start bar.torrent and torrent number 7.
-.br
-.RS 4
-.B $ btcli start bar.torrent 7
-.RE
-.PP
-Stop torrent number 7.
-.br
-.RS 4
-.B $ btcli stop 7
-.RE
-.PP
-Stop all active torrents.
-.br
-.RS 4
-.B $ btcli stop \-a
-.RE
-.PP
-Remove bar.torrent and it's associated information from btpd.
-.br
-.RS 4
-.B $ btcli del bar.torrent
-.RE
-.PP
-Display a summary of up/download stats for the active torrents.
-.br
-.RS 4
-.B $ btcli stat
-.RE
-.PP
-Display the summary once every five seconds.
-.br
-.RS 4
-.B $ btcli stat \-w 5
-.RE
-.PP
-Same as above, but also display individual stats for each active torrent.
-.br
-.RS 4
-.B $ btcli stat \-w 5 \-i
-.RE
-.PP
-Set the global upload rate to 20KB/s and download rate to 1MB/s.
-.br
-.RS 4
-.B $ btcli rate 20K 1M
-.RE
-.PP
+.Bl -tag -width Ds
+.It Cm add
+Add torrents to btpd.
+.It Cm del
+Remove torrents from btpd.
+.It Cm kill
 Shut down btpd.
-.br
-.RS 4
-.B $ btcli kill
-.RE
-.SH "BUGS"
-Known bugs are listed at \fIhttp://github.com/btpd/btpd/issues\fR
-.sp
-Before submitting a bug report, please verify that you are running the latest version of btpd.
-.SH "AUTHORS"
-.sp
+.It Cm list
+List torrents.
+.It Cm rate
+Set the global up and download rates in kB/s.
+.It Cm start
+Activate torrents.
+.It Cm stat
+Display stats for active torrents.
+.It Cm stop
+Deactivate torrents.
+.It Fl -help Ar operation
+Show help for the specified
+.Ar operation .
+.El
+.Sh ADD OPTIONS
+.Cm add
+supports the following options:
+.Bl -tag -width Ds
+.It Fl d Ar dir
+Specifies the directory in which the files in the torrent will be downloaded;
+it does not specify
+.Xr btpd 1 Ns 's
+.Dq work
+directory.
+That is gathered from the environment variable
+.Ev $HOME .
+.It Fl N , Fl -nostart
+Do not start the torrent immediately after adding it.
+.It Fl T , Fl -topdir
+Append the torrent top directory (if any) to the content path.
+.It Fl n Ar name
+Specifies the name to be displayed for this torrent.
+.It Fl l Ar label
+Set the label to associate with torrent.
+.El
+.Sh LIST OPTIONS
+.Cm list
+supports the following options:
+.Bl -tag -width Ds
+.It Fl a
+List active torrents.
+.It Fl i
+List inactive torrents.
+.It Fl f Ar format
+Specifies a custom format to use while displaying torrents.
+The following is a list of the characters that can be used:
+.Bl -diag
+.It %n
+torrent name
+.It %#
+torrent number
+.It %h
+torrent hash
+.It %l
+torrent label
+.It %d
+download directory
+.It %t
+state
+.It %P
+peer count
+.It %^
+upload rate
+.It %v
+download rate
+.It %D
+downloaded bytes
+.It %U
+uploaded bytes
+.It %g
+bytes got
+.It %u
+bytes uploaded
+.It %s
+total size, (formatted: prints K, M, G)
+.It %S
+total size, in bytes
+.It %A
+available pieces
+.It %T
+total pieces
+.It %H
+have pieces
+.It %p
+percent have (formatted)
+.It %r
+ratio
+.It %%
+a percent symbol:
+.Ql %
+.El
+.El
+.Sh STAT OPTIONS
+.Cm stat
+supports the following options:
+.Bl -tag -width Ds
+.It Fl i
+Display individual lines for each torrent.
+.It Fl n
+Display the name of each torrent.
+Implies
+.Fl i .
+.El
+.Sh START OPTIONS
+.Cm start
+supports the following options:
+.Bl -tag -width Ds
+.It Fl a
+Activate all inactive torrents.
+.El
+.Sh STOP OPTIONS
+.Cm stop
+supports the following options:
+.Bl -tag -width Ds
+.It Fl a
+Deactivate all torrents.
+.El
+.Sh USAGE
+.Xr btpd 1
+must be started before
+.Nm
+can be used.
+.Pp
+To start sharing a torrent with btpd, the torrent needs to be added to btpd.
+This is done with
+.Nm
+.Cm add .
+Unless otherwise specified,
+btpd automatically starts to share the torrent and download any missing data.
+If the content directory you specify when adding a torrent does not exist,
+btpd will create it.
+.Pp
+You can see which torrents have been added to btpd with
+.Nm
+.Cm list .
+The list mode also displays a number for each added torrent.
+This number can be used to specify the target torrent for the btcli modes,
+so you don't have to keep the torrent file after adding it.
+.Pp
+The upload and download progress can be followed by using the
+.Nm
+.Cm stat
+mode.
+Both the list and stat modes use the following indicators to display the state
+of a torrent:
+.Bl -inset
+.It +
+The torrent is starting.
+This may take time if btpd needs to test the content of this torrent or one
+started before it.
+.It -
+The torrent is being stopped.
+.It I
+The torrent is inactive.
+.It S
+btpd is seeding the torrent.
+.It L
+btpd is leeching the torrent.
+.El
+.Pp
+You can stop an active torrent with
+.Nm
+.Cm stop .
+You can start an inactive torrent by using
+.Nm
+start .
+.Pp
+.Sy Note :
+Torrents can be specified either with its number or its file.
+.Pp
+The
+.Nm
+.Cm del
+mode should only be used when you're totally finished with sharing a torrent.
+The mode will remove the torrent and its associated data from btpd.
+It is a bad idea to remove a not fully downloaded torrent and then add it
+again, since btpd has lost information on the not fully downloaded pieces and
+will need to download the data again.
+.Pp
+To shut down btpd use
+.Nm
+.Cm kill .
+.Sh EXAMPLES
+Display a list of btpd's torrents and their number, size, status, etc.
+.Dl $ btcli list
+.Pp
+Same as above, but only for torrent 12 and
+.Pa my.little.torrent .
+.Dl $ btcli list 12 my.little.torrent
+.Pp
+Same as above but only for active torrents.
+.Dl $ btcli list -a
+.Pp
+Add
+.Pa foo.torrent ,
+with content dir
+.Pa foo.torrent.d ,
+and start it.
+.Dl $ btcli add -d foo.torrent.d foo.torrent
+.Pp
+Same as above without starting it.
+.Dl $ btcli add -N -d foo.torrent.d foo.torrent
+.Pp
+Start
+.Pa bar.torrent
+and torrent number 7.
+.Dl $ btcli start bar.torrent 7
+.Pp
+Stop torrent number 7.
+.Dl $ btcli stop 7
+.Pp
+Stop all active torrents.
+.Dl $ btcli stop -a
+.Pp
+Remove
+.Pa bar.torrent
+and its associated information from btpd.
+.Dl $ btcli del bar.torrent
+.Pp
+Display a summary of up/download stats for the active torrents.
+.Dl $ btcli stat
+.Pp
+Display the summary once every five seconds.
+.Dl $ btcli stat -w 5
+.Pp
+Same as above, but also display individual stats for each active torrent.
+.Dl $ btcli stat -w 5 -i
+.Pp
+Set the global upload rate to 20 kB/s and download rate to 1 MB/s.
+.Dl $ btcli rate 20K 1M
+.Pp
+Shut down btpd.
+.Dl $ btcli kill
+.Sh SEE ALSO
+.Xr btinfo 1 ,
+.Xr btpd 1
+.Sh AUTHORS
+.An -nosplit
 Current maintainers:
-.sp
-\- Marq Schneider <\fIqueueRAM@gmail.com\fR>
-.sp
+.Bl -bullet
+.It
+.An Marq Schneider Aq Mt queueRAM@gmail.com
+.El
+.Pp
 Past contributors:
-.sp
-\- Richard Nyberg <\fIbtpd@murmeldjur.se\fR> 
-.SH "SEE ALSO"
-.BR \fBbtpd\fR(1)
-.BR \fBbtinfo\fR(1)
-
+.Bl -bullet
+.It
+Richard Nyberg
+.Aq Mt btpd@murmeldjur.se
+.El
+.Sh BUGS
+Known bugs are listed at
+.Lk https://github.com/btpd/btpd/issues .
+.Pp
+Before submitting a bug report,
+please verify that you are running the latest version of
+.Xr btpd 1 .

--- a/doc/btcli.1
+++ b/doc/btcli.1
@@ -15,29 +15,36 @@ is a utility that interacts with a running
 daemon.
 It has several different modes of operation.
 .Sh OPERATIONS
-One of the following operations must be specified when running btcli:
+.Nm
+supports the following commands:
+.Sx add ,
+.Sx del ,
+.Sx kill ,
+.Sx list ,
+.Sx rate ,
+.Sx start ,
+.Sx stat ,
+and
+.Sx stop .
+.Pp
+.Nm
+accepts only one option:
 .Bl -tag -width Ds
-.It Cm add
-Add torrents to btpd.
-.It Cm del
-Remove torrents from btpd.
-.It Cm kill
-Shut down btpd.
-.It Cm list
-List torrents.
-.It Cm rate
-Set the global up and download rates in kB/s.
-.It Cm start
-Activate torrents.
-.It Cm stat
-Display stats for active torrents.
-.It Cm stop
-Deactivate torrents.
 .It Fl -help Ar operation
 Show help for the specified
 .Ar operation .
 .El
-.Sh ADD OPTIONS
+.Ss add
+.Nm btcli
+.Cm add
+.Op Fl NT
+.Op Fl l Ar label
+.Op Fl n Ar name
+.Fl d Ar dir
+.Ar
+.Pp
+Add torrents to btpd.
+.Pp
 .Cm add
 supports the following options:
 .Bl -tag -width Ds
@@ -48,7 +55,7 @@ it does not specify
 .Dq work
 directory.
 That is gathered from the environment variable
-.Ev $HOME .
+.Ev HOME .
 .It Fl N , Fl -nostart
 Do not start the torrent immediately after adding it.
 .It Fl T , Fl -topdir
@@ -58,14 +65,32 @@ Specifies the name to be displayed for this torrent.
 .It Fl l Ar label
 Set the label to associate with torrent.
 .El
-.Sh LIST OPTIONS
+.Ss del
+.Nm btcli
+.Cm del
+.Ar
+.Pp
+Remove the given torrents from btpd.
+.Ss kill
+.Nm btcli
+.Cm kill
+.Pp
+Shut down btpd.
+.Ss list
+.Nm btcli
+.Cm list
+.Op Fl ai
+.Op Fl f Ar format
+.Op Ar
+.Pp
+List the given torrents,
+or all torrents (active or inactive) if no arguments are given.
+.Pp
 .Cm list
 supports the following options:
 .Bl -tag -width Ds
 .It Fl a
 List active torrents.
-.It Fl i
-List inactive torrents.
 .It Fl f Ar format
 Specifies a custom format to use while displaying torrents.
 The following is a list of the characters that can be used:
@@ -114,8 +139,25 @@ ratio
 a percent symbol:
 .Ql %
 .El
+.It Fl i
+List inactive torrents.
 .El
-.Sh STAT OPTIONS
+.Ss rate
+.Nm btcli
+.Cm rate
+.Ar up
+.Ar down
+.Pp
+Set the global upload and download rates in kB/s.
+.Ss stat
+.Nm btcli
+.Cm stat
+.Op Fl in
+.Op Fl w Ar num
+.Op Ar
+.Pp
+Display stats for active torrents.
+.Pp
 .Cm stat
 supports the following options:
 .Bl -tag -width Ds
@@ -125,15 +167,38 @@ Display individual lines for each torrent.
 Display the name of each torrent.
 Implies
 .Fl i .
+.It Fl w Ar num
+Display stats every
+.Ar num
+seconds.
 .El
-.Sh START OPTIONS
+.Ss start
+.Nm btcli
+.Cm start
+.Ar
+.Pp
+.Nm btcli
+.Cm start
+.Fl a
+.Pp
+Activate torrents.
 .Cm start
 supports the following options:
 .Bl -tag -width Ds
 .It Fl a
 Activate all inactive torrents.
 .El
-.Sh STOP OPTIONS
+.Ss stop
+.Nm btcli
+.Cm stop
+.Ar
+.Pp
+.Nm btcli
+.Cm stop
+.Fl a
+.Pp
+Deactivate torrents.
+.Pp
 .Cm stop
 supports the following options:
 .Bl -tag -width Ds

--- a/doc/btinfo.1
+++ b/doc/btinfo.1
@@ -1,22 +1,18 @@
-.TH BTINFO "1" "2010\-07\-31" "BitTorrent Protocol Daemon 0.16" "User Commands"
-.\" disable hyphenation
-.nh
-.\" adjust text to left margin only
-.ad l
-.\" -----------------------------------------------------------------
-.\" MAIN CONTENT
-.\" -----------------------------------------------------------------
-.SH "NAME"
-btinfo \- BitTorrent Protocol Daemon information
-.SH "SYNOPSIS"
-.B btinfo
-\fIfile\fR
-.SH "EXAMPLE"
-List the torrent information for \fBosol\-0906\-x86.iso.torrent\fR
-.PP
-.nf
-.B $ btinfo /var/torrents/osol\-0906\-x86.iso.torrent
-Name: osol\-0906\-x86.iso
+.Dd May 10, 2015
+.Dt BTINFO 1
+.Os
+.Sh NAME
+.Nm btinfo
+.Nd BitTorrent Protocol Daemon information
+.Sh SYNOPSIS
+.Nm btinfo
+.Ar
+.Sh EXAMPLES
+List the torrent information for
+.Pa osol-0906-x86.iso.torrent :
+.Bd -literal
+$ btinfo /var/torrents/osol-0906-x86.iso.torrent
+Name: osol-0906-x86.iso
 Info hash: 58aca632a9f68427a8ac8f58cafa7a72ca067dba
 Tracker URLs: [ [ http://dlc.sun.com:6969/announce ] [ http://dlc.sun.com:16969/announce ] ]
 Number of pieces: 1354
@@ -24,24 +20,29 @@ Piece size: 524288
 Total size: 709871616
 Number of files: 1
 Files:
-osol\-0906\-x86.iso (709871616)
-.fi
-.SH "TROUBLESHOOTING"
-If \fBbtpd\fR has shut down for some unknown reason, check the logfile for possible clues.
-.SH "BUGS"
-Known bugs are listed at \fIhttp://github.com/btpd/btpd/issues\fR
-.sp
-Before submitting a bug report, please verify that you are running the latest version of btpd.
-.SH "AUTHORS"
-.sp
+osol-0906-x86.iso (709871616)
+.Ed
+.Sh SEE ALSO
+.Xr btcli 1 ,
+.Xr btpd 1
+.Sh AUTHORS
+.An -nosplit
 Current maintainers:
-.sp
-\- Marq Schneider <\fIqueueRAM@gmail.com\fR>
-.sp
+.Bl -bullet
+.It
+.An Marq Schneider Aq Mt queueRAM@gmail.com
+.El
+.Pp
 Past contributors:
-.sp
-\- Richard Nyberg <\fIbtpd@murmeldjur.se\fR> 
-.SH "SEE ALSO"
-.BR \fBbtpd\fR(1)
-.BR \fBbtcli\fR(1)
-
+.Bl -bullet
+.It
+Richard Nyberg
+.Aq Mt btpd@murmeldjur.se
+.El
+.Sh BUGS
+Known bugs are listed at
+.Lk http://github.com/btpd/btpd/issues .
+.Pp
+Before submitting a bug report,
+please verify that you are running the latest version of
+.Xr btpd 1 .

--- a/doc/btpd.1
+++ b/doc/btpd.1
@@ -1,140 +1,214 @@
-.TH BTPD "1" "2010\-07\-31" "BitTorrent Protocol Daemon 0.16" "User Commands"
-.\" disable hyphenation
-.nh
-.\" adjust text to left margin only
-.ad l
-.\" -----------------------------------------------------------------
-.\" MAIN CONTENT
-.\" -----------------------------------------------------------------
-.SH "NAME"
-btpd \- BitTorrent Protocol Daemon
-.SH "SYNOPSIS"
-.B btpd
-[\fB\-d\fR \fIdir\fR]
-[\fB\-p\fR \fIport\fR]
-[\fBOPTIONS\fR...] 
-.SH "DESCRIPTION"
-Btpd is a utility for sharing files over the BitTorrent network protocol.  It runs in daemon mode, thus needing no controlling terminal or gui.  Instead, the daemon is controlled by \fBbtcli\fR, its control utility, or other programs capable of sending commands and queries on the control socket.
-.PP
-btpd consists of the following programs:
-.RS 4
-\fBbtpd\fR \- The bittorrent client.
-.br
-\fBbtcli\fR \- Command line interface to btpd.
-.br
-\fBbtinfo\fR \- Shows information from a torrent file.
-.RE
-.PP
-All programs accept the \fB\-\-help\fR option.
-
-.SH "OPTIONS"
-.TP
-\fB\-d\fR \fIdir\fR
-The path for the btpd directory.  Default is \fI$HOME/.btpd\fR.
-.TP
-\fB\-p\fR \fIn\fR, \fB\-\-port\fR \fIn\fR 
-Listen at port \fIn\fR. Default is 6881.
-.TP
-\fB\-\-help\fR [\fImode\fR] 
+.Dd May 10, 2015
+.Dt BTPD 1
+.Os
+.Sh NAME
+.Nm btpd
+.Nd BitTorrent Protocol Daemon
+.Sh SYNOPSIS
+.Nm btpd
+.Op Fl d Ar dir
+.Op Fl p Ar port
+.Op Ar options ...
+.Sh DESCRIPTION
+.Nm
+is a utility for sharing files over the BitTorrent network protocol.
+It runs in daemon mode, thus needing no controlling terminal or gui.
+Instead, the daemon is controlled by
+.Xr btcli 1 ,
+its control utility, or other programs capable of sending commands and queries
+on the control socket.
+.Pp
+.Nm
+consists of the following programs:
+.Bl -tag -width btinfo(1)XX
+.It Nm btpd
+The bittorrent client.
+.It Xr btcli 1
+Command line interface to btpd.
+.It Xr btinfo 1
+Shows information from a torrent file.
+.El
+.Pp
+All programs accept the
+.Fl -help
+option.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl d Ar dir
+The path for the btpd directory.
+Default is
+.Pa $HOME/.btpd .
+.It Fl p Ar n , Fl -port Ar n
+Listen at port
+.Ar n .
+Default is 6881.
+.It Fl -help Op Ar mode
 Show this text or help for the specified mode.
-.TP
-.B \-4
-Use IPv4. If given in conjunction with \fB\-6\fR, both versions are used.
-.TP
-.B \-6
-Use IPv6. By default IPv4 is used.
-Unfortunately enabling both IPv6 and IPv4 in btpd is less useful than it should be. The problem is that some sites have trackers for both versions and it's likely that the IPv6 one, which probably has less peers, will be used in favour of the IPv4 one.
-.TP
-.B \-\-bw\-in \fIn\fR
-Limit incoming BitTorrent traffic to \fIn\fR kB/s.  Default is 0 which means unlimited.
-.TP
-.B \-\-bw\-out \fIn\fR
-Limit outgoing BitTorrent traffic to \fIn\fR kB/s.  Default is 0 which means unlimited.
-.TP
-.B \-\-empty\-start
-Start btpd without any active torrents.
-.TP
-.B \-\-ip \fIaddr\fR
-Let the tracker distribute the given address instead of the one it sees btpd connect from.
-.TP
-.B \-\-ipcprot \fImode\fR
-Set the protection mode of the command socket.  The mode is specified by an octal number. Default is 0600.
-.TP
-.B \-\-logfile \fIfile\fR
-Where to put the logfile. By default it's put in the btpd dir.
-.TP
-.B \-\-logmask \fImask\fR
-Bitfield to specify which data to record in the btpd log (dev info).
-.TP
-.B \-\-max\-peers \fIn\fR
-Limit the amount of peers to \fIn\fR.
-.TP
-.B \-\-max\-uploads \fIn\fR
-Controls the number of simultaneous uploads.  The possible values are:
-.RS
-\fIn\fR < \-1 : Choose \fIn\fR >= 2 based on \fB\-\-bw\-out\fR (default).
-.br
-\fIn\fR = \-1 : Upload to every interested peer.
-.br
-\fIn\fR =  0 : Dont't upload to anyone.
-.br
-\fIn\fR >  0 : Upload to at most n peers simultaneously.
-.RE
-.TP
-.B \-\-no\-daemon
-Keep the btpd process in the foregorund and log to std{out,err}.  This option is intended for debugging purposes.
-.TP
-.B \-\-prealloc \fIn\fR
-Preallocate disk space in chunks of \fIn\fR kB. Default is 2048.  Note that \fIn\fR will be rounded up to the closest multiple of the torrent piece size. If \fIn\fR is zero no preallocation will be done.
-.TP
-.B \-\-numwant \fIn\fR
-Specify the number of wanted peers 'numwant' tracker request parameter. Default is 50.
-.SH "STARTING BTPD"
-To start btpd with default settings you only need to run it. However, there are many useful options you may want to use. To see a full list run \fBbtpd \-\-help\fR. If you didn't specify otherwise,  btpd starts with the same set of active torrents as it had the last time it was shut down.
-.PP
-\fBbtdp\fR will store information and write its log in \fI$HOME/.btpd\fR. Therefore it needs to be able to write there during its execution. You can specify another directory via the \fB\-d\fR option or the \fI$BTPD_HOME\fR variable.
-.PP
-It is recommended to specifiy the maximum number of uploads. Bittorrent employs a tit for tat algorithm, so uploading at good rates allows for downloading.  Try to find a balance between uploads/outgoing bandwidth and the number of active torrents.
-.PP
-.B Note: 
-You should only need one instance of btpd regardless of how many torrents you want to share.
-.SH "EXAMPLES"
-Start btpd with all options set to their default values.
-.RS 4
-.nf
-.B $ btpd
-.fi
-.RE
-.PP
-Start btpd as above, but with torrent data in the directory /var/torrents
-.RS 4
-.nf
-.B $ btpd \-d /var/torrents
-.fi
-.RE
-.PP
-Start btpd and make it listen on port 12345, limit outgoing bandwidth to 200kB/s, limit the number of peers to 40 and not start any torrents that were active the last time btpd was shut down.
-.RS 4
-.nf
-.B $ btpd \-p 12345 \-\-bw\-out 200 \-\-max\-peers 40 \-\-empty\-start
-.fi
-.RE
-.SH "TROUBLESHOOTING"
-If \fBbtpd\fR has shut down for some unknown reason, check the logfile for possible clues.
-.SH "BUGS"
-Known bugs are listed at \fIhttp://github.com/btpd/btpd/issues\fR
-.sp
-Before submitting a bug report, please verify that you are running the latest version of btpd.
-.SH "AUTHORS"
-.sp
+.It Fl 4
+Use IPv4.
+If given in conjunction with
+.Fl 6 ,
+both versions are used.
+.It Fl 6
+Use IPv6.
+By default IPv4 is used.
+.Pp
+Unfortunately enabling both IPv6 and IPv4 in btpd is less useful than it should
+be.
+The problem is that some sites have trackers for both versions and it's likely
+that the IPv6 one, which probably has less peers, will be used in favour of the
+IPv4 one.
+.It Fl -bw-in Ar n
+Limit incoming BitTorrent traffic to
+.Ar n
+kB/s.
+Default is 0 which means unlimited.
+.It Fl -bw-out Ar n
+Limit outgoing BitTorrent traffic to
+.Ar n
+kB/s.
+Default is 0 which means unlimited.
+.It Fl -empty-start
+Start
+.Nm
+without any active torrents.
+.It Fl -ip Ar addr
+Let the tracker distribute the given address instead of the one it sees
+.Nm
+connect from.
+.It Fl -ipcprot Ar mode
+Set the protection mode of the command socket.
+The mode is specified by an octal number.
+Default is 0600.
+.Fl -logfile Ar file
+Where to put the logfile.
+By default it's put in the
+.Nm
+dir.
+.It Fl -logmask Ar mask
+Bitfield to specify which data to record in the
+.Nm
+log (dev info).
+.It Fl -max-peers Ar n
+Limit the amount of peers to
+.Ar n .
+.It Fl -max-uploads Ar n
+Controls the number of simultaneous uploads.
+The possible values are:
+.Bl -inset
+.It < \(mi1
+Choose
+.Ar n
+\(>= 2 based on
+.Fl -bw-out
+(default).
+.It = \(mi1
+Upload to every interested peer.
+.It = 0
+Don't upload to anyone.
+.It > 0
+Upload to at most n peers simultaneously.
+.El
+.It Fl -no-daemon
+Keep the
+.Nm
+process in the foregorund and log to
+.Dv stdout
+and
+.Dv stderr .
+This option is intended for debugging purposes.
+.It Fl -prealloc Ar n
+Preallocate disk space in chunks of
+.Ar n
+kB.
+Default is 2048.
+Note that
+.Ar n
+will be rounded up to the closest multiple of the torrent piece size.
+If
+.Ar n
+is zero no preallocation will be done.
+.It Fl -numwant Ar n
+Specify the number of wanted peers
+.Sq numwant
+tracker request parameter.
+Default is 50.
+.El
+.Sh STARTING BTPD
+To start btpd with default settings you only need to run it with no arguments.
+However, there are many useful options you may want to use.
+To see a full list run
+.Nm
+.Fl -help .
+If you didn't specify otherwise,
+.Nm btpd
+starts with the same set of active torrents as it had the last time it was shut
+down.
+.Pp
+.Nm btpd
+will store information and write its log in
+.Pa $HOME/.btpd .
+Therefore it needs to be able to write there during its execution.
+You can specify another directory via the
+.Fl d
+option or the
+.Ev BTPD_HOME
+variable.
+.Pp
+It is recommended to specify the maximum number of uploads.
+Bittorrent employs a tit for tat algorithm,
+so uploading at good rates allows for downloading.
+Try to find a balance between uploads/outgoing bandwidth and the number of
+active torrents.
+.Pp
+.Sy Note :
+You should only need one instance of
+.Nm
+regardless of how many torrents you want to share.
+.Sh EXAMPLES
+Start
+.Nm
+with all options set to their default values.
+.Dl $ btpd
+.Pp
+Start
+.Nm
+as above, but with torrent data in the directory
+.Pa /var/torrents .
+.Dl $ btpd -d /var/torrents
+.Pp
+Start btpd and make it listen on port 12345,
+limit outgoing bandwidth to 200kB/s,
+limit the number of peers to 40
+and not start any torrents that were active the last time
+.Nm
+was shut down.
+.Dl $ btpd -p 12345 --bw-out 200 --max-peers 40 --empty-start
+.Sh TROUBLESHOOTING
+If
+.Nm
+has shut down for some unknown reason, check the logfile for possible clues.
+.Sh SEE ALSO
+.Xr btcli 1 ,
+.Xr btinfo 1
+.Sh AUTHORS
+.An -nosplit
 Current maintainers:
-.sp
-\- Marq Schneider <\fIqueueRAM@gmail.com\fR>
-.sp
+.Bl -bullet
+.It
+.An Marq Schneider Aq Mt queueRAM@gmail.com
+.El
+.Pp
 Past contributors:
-.sp
-\- Richard Nyberg <\fIbtpd@murmeldjur.se\fR> 
-.SH "SEE ALSO"
-.BR \fBbtcli\fR(1)
-.BR \fBbtinfo\fR(1)
-
+.Bl -bullet
+.It
+Richard Nyberg
+.Aq Mt btpd@murmeldjur.se
+.El
+.Sh BUGS
+Known bugs are listed at
+.Lk http://github.com/btpd/btpd/issues .
+.Pp
+Before submitting a bug report,
+please verify that you are running the latest version of
+.Nm btpd .


### PR DESCRIPTION
Reorganize the btcli(1) manual to provide descriptions for each command all in one place. Also, rewrite all manpages with the simpler, more semantic `-mdoc` macro set, a drop‐in replacement.